### PR TITLE
FastBoot compatibility with ember-cli-head

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ For any other app, follow the scheme outlined in the blog post. Previous version
 ember install ember-page-title
 ```
 
+#### Post Install Cleanup
+
+As of v3.0.0 this addon maintains the page title by using the
+`<title>` tag in your document's `<head>`.  This is necessary for
+[FastBoot](https://github.com/tildeio/ember-cli-fastboot)
+compatibility.
+
+For proper functioning you will need to remove the default `<title>`
+tag from `app/index.html`.
+
 ### Digging in
 
 [Visit the Docs site](http://tim-evans.github.io/ember-page-title/)

--- a/addon/helpers/page-title.js
+++ b/addon/helpers/page-title.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 
-const get = Ember.get;
-const { guidFor } = Ember;
+const { get, set, guidFor } = Ember;
 
 function updateTitle(tokens) {
-  document.title = tokens.toString();
+  set(this, 'headData.title', tokens.toString());
 }
 
 export default Ember.Helper.extend({
   pageTitleList: Ember.inject.service(),
+  headData: Ember.inject.service(),
 
   init() {
     this._super();
@@ -21,7 +21,7 @@ export default Ember.Helper.extend({
     hash.id = guidFor(this);
     hash.title = params.join('');
     tokens.push(hash);
-    Ember.run.scheduleOnce('afterRender', null, updateTitle, tokens);
+    Ember.run.scheduleOnce('afterRender', this, updateTitle, tokens);
     return '';
   },
 
@@ -29,6 +29,6 @@ export default Ember.Helper.extend({
     let tokens = get(this, 'pageTitleList');
     let id = guidFor(this);
     tokens.remove(id);
-    Ember.run.scheduleOnce('afterRender', null, updateTitle, tokens);
+    Ember.run.scheduleOnce('afterRender', this, updateTitle, tokens);
   }
 });

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,5 @@
+<!-- `app/templates/head.hbs` -->
+<!-- content from ember-page-title, injected by ember-cli-head -->
+<!-- The 'model' available in this template can be populated by -->
+<!-- setting values on the 'head-data' service. -->
+<title>{{model.title}}</title>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-head": "0.0.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-head": "0.0.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
@@ -48,6 +47,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-cli-head": "0.0.5",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-page-title",
-  "version": "2.0.7",
+  "version": "3.0.0",
   "description": "{{title}} for Ember applications",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -19,7 +19,7 @@ test('the default configuration works', function(assert) {
   visit('/posts');
 
   andThen(function() {
-    assert.equal(document.title, 'My App | Posts');
+    assert.equal(findWithAssert('title', 'head').text(), 'My App | Posts');
   });
 });
 
@@ -28,7 +28,7 @@ test('the replace attribute works', function(assert) {
   visit('/about');
 
   andThen(function() {
-    assert.equal(document.title, 'About My App');
+    assert.equal(findWithAssert('title', 'head').text(), 'About My App');
   });
 });
 
@@ -37,7 +37,7 @@ test('custom separators work', function(assert) {
   visit('/about/authors');
 
   andThen(function() {
-    assert.equal(document.title, 'About My App > Authors');
+    assert.equal(findWithAssert('title', 'head').text(), 'About My App > Authors');
   });
 });
 
@@ -46,7 +46,7 @@ test('custom separators are inherited', function(assert) {
   visit('/about/authors/profile');
 
   andThen(function() {
-    assert.equal(document.title, 'About My App > Authors > Profile');
+    assert.equal(findWithAssert('title', 'head').text(), 'About My App > Authors > Profile');
   });
 });
 
@@ -55,7 +55,7 @@ test('multiple components in a row work', function(assert) {
   visit('/posts/rails-is-omakase');
 
   andThen(function() {
-    assert.equal(document.title, 'My App | Posts | Rails is Omakase');
+    assert.equal(findWithAssert('title', 'head').text(), 'My App | Posts | Rails is Omakase');
   });
 });
 
@@ -64,7 +64,7 @@ test('the prepend declaration works', function(assert) {
   visit('/authors/tomster');
 
   andThen(function() {
-    assert.equal(document.title, 'My App | Tomster < Authors');
+    assert.equal(findWithAssert('title', 'head').text(), 'My App | Tomster < Authors');
   });
 });
 
@@ -73,7 +73,7 @@ test('replace nested in prepends work', function(assert) {
   visit('/hollywood');
 
   andThen(function() {
-    assert.equal(document.title, 'Hollywood ★ Stars everywhere');
+    assert.equal(findWithAssert('title', 'head').text(), 'Hollywood ★ Stars everywhere');
   });
 });
 
@@ -82,6 +82,6 @@ test('multitoken titles work', function(assert) {
   visit('/feeds/tomster');
 
   andThen(function() {
-    assert.equal(document.title, 'Tomster (@tomster)');
+    assert.equal(findWithAssert('title', 'head').text(), 'Tomster (@tomster)');
   });
 });

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>ember-page-title</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="assets/images/icon.png">

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>ember-page-title</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
This will add FastBoot compatibility by way of `ember-cli-head`.

There are 2 outstanding issues I'd like to resolve before this get merged:
 - [x] I know @tim-evans wants to ensure consuming apps don't need to change for this functionality.  As it sits now the original `<title>` tag in an app's `index.html` would need to be removed since `ember-cli-head` provides it's own content but doesn't directly manipulate document.title.  I think there are a few options to address this (all of which have potential downsides):
   1. Make the release version a semantic API bump (3.0.0) and provide upgrade instructions to remove your existing `<title>` tag.  This is the implementation as it currently stands in this PR.
   2. Have branching logic around the setting of the head data to set document when FastBoot is not present, and use headData when FastBoot is found.  Downside here is we'd be needlessly pulling in ember-cli-head in those scenarios and we'd need to wrap the display of title in `head.hbs` with an if clause.
   3. Or I go back on my initial thought and do try to tackle this in `ember-cli-head`.  Then we could use the approach in **ii.** but isolate the ugliness to `ember-cli-head`.  This would have the downside of either adding an observer or an explicit setTitle method to the headData service, neither of which I'm not crazy about.
 - [x] I also need to test it out in a consuming app and ensure everything installs correctly.  Acceptance tests are passing for the dummy application (at least in ember release), but need to be certain apps don't run into issues.

Let me know what you think.  Once we come to a consensus I can clean it up and test it in a consuming app.