### PR TITLE
bump ember-cli-head version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-head": "0.0.5",
+    "ember-cli-head": "0.0.6",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {


### PR DESCRIPTION
Simple version bump on ember-cli-head.  Should be gtg once tests pass.