### PR TITLE
Do not load ast transformation for {{title}} in addons/engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
 
     // Do not add ast conversion in addons/engines
     // This means that inside of addons/engines, you can only use {{page-title}}, not {{title}}
-    let app = this.app;
+    var app = this.app;
     if (typeof app !== 'undefined' && typeof app.registry !== 'undefined') {
       app.registry.add('htmlbars-ast-plugin', {
         name: 'translate-title-helper-to-page-title-helper',

--- a/index.js
+++ b/index.js
@@ -9,9 +9,14 @@ module.exports = {
   included: function () {
     this._super.included.apply(this, arguments);
 
-    this.app.registry.add('htmlbars-ast-plugin', {
-      name: 'translate-title-helper-to-page-title-helper',
-      plugin: TranslateHelperName
-    });
+    // Do not add ast conversion in addons/engines
+    // This means that inside of addons/engines, you can only use {{page-title}}, not {{title}}
+    let app = this.app;
+    if (typeof app !== 'undefined' && typeof app.registry !== 'undefined') {
+      app.registry.add('htmlbars-ast-plugin', {
+        name: 'translate-title-helper-to-page-title-helper',
+        plugin: TranslateHelperName
+      });
+    }
   }
 };


### PR DESCRIPTION
In order to enable #38 and #31, we cannot load the ast transformation in addon context. While this PR is not an ideal fix, it at least enables the usage of `{{page-title}}` in addons/engines. 