### PR TITLE
helpers/page-title: Clone the hash parameter to make it extendable

### DIFF
--- a/addon/helpers/page-title.js
+++ b/addon/helpers/page-title.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { get, set, guidFor } = Ember;
+const { get, set, guidFor, merge } = Ember;
 
 function updateTitle(tokens) {
   set(this, 'headData.title', tokens.toString());
@@ -16,8 +16,9 @@ export default Ember.Helper.extend({
     tokens.push({ id: guidFor(this) });
   },
 
-  compute(params, hash) {
+  compute(params, _hash) {
     let tokens = get(this, 'pageTitleList');
+    let hash = merge({}, _hash);
     hash.id = guidFor(this);
     hash.title = params.join('');
     tokens.push(hash);


### PR DESCRIPTION
Fixes the "TypeError: Attempted to assign to readonly property." with the current Ember.js canary branch

resolves parts of https://github.com/emberjs/ember.js/issues/14187