### PR TITLE
Allow title tag to remain on non-fastboot apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ ember install ember-page-title
 
 #### Post Install Cleanup
 
-As of v3.0.0 this addon maintains the page title by using the
-`<title>` tag in your document's `<head>`.  This is necessary for
-[FastBoot](https://github.com/tildeio/ember-cli-fastboot)
-compatibility.
+As of v3.0.0 this addon maintains the page title by using the `<title>` tag in your document's `<head>`.  This is necessary for [FastBoot](https://github.com/tildeio/ember-cli-fastboot) compatibility.
 
-For proper functioning you will need to remove the default `<title>`
-tag from `app/index.html`.
+Non-fastboot apps should keep the `<title>` tag in your index.html to ensure that the initial page served is valid HTML. The title will be replaced when your app boots.
+
+Fastboot-only apps can safely remove the `<title>` tag if desired.
 
 ### Digging in
 
@@ -38,7 +36,7 @@ When working with other addons that use `ember-cli-head`, you'll need to create 
 <title>{{model.title}}</title>
 ```
 
-This is for all the folks using ember-cli-head addons like ember-cli-meta-tags.
+This file is added automatically if you use `ember install`. This is for all the folks using ember-cli-head addons like ember-cli-meta-tags.
 
 ### API
 

--- a/app/initializers/page-title-setup.js
+++ b/app/initializers/page-title-setup.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default {
+  name: 'page-title-setup',
+  initialize() {
+    // Remove <title> tags from the initial index.html page, so they can be correctly replaced
+    // and managed by ember-cli-head.
+    Ember.$('title').remove();
+  },
+};

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>Initial page title - removed by addon initializer</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>ember-page-title tests</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">


### PR DESCRIPTION
Fixes #28 and #37.

This adds an initializer to remove the base index.html's `<title>` tag before it is taken over by ember-cli-head (turns out an instance initializer is too late in the boot process, so I made it a normal initializer).

This allows people to keep the initial `<title>` tag in index.html and adds a recommendation to the README to that effect. Not only is an initial `<title>` good for SEO (for non-JavaScript enabled search engines), an HTML5 page is not actually valid without a title.

Tested:
- The current test suite correctly died when `<title>` was added to the dummy app index.html. Adding the initializer made the test suite pass again, so I'm pretty confident the current test suite covers this behavior adequately without additional tests.

Manually tested:
- Initial title load and takeover in a non-fastboot app with `<title>` present in index.html (forwards-compatibility).
- Initial title load and takeover in a non-fastboot app with `<title>` absent in index.html (backwards compatibility with people who have already removed it).

Untested:
- Fastboot app.