### PR TITLE
Fix deprecation warning of router

### DIFF
--- a/addon/helpers/page-title.js
+++ b/addon/helpers/page-title.js
@@ -31,7 +31,9 @@ export default Ember.Helper.extend({
     let id = guidFor(this);
     tokens.remove(id);
 
-    let activeTransition = getOwner(this).lookup('router:main').get('router.activeTransition');
+    let router = getOwner(this).lookup('router:main');
+    let routes = router._routerMicrolib || router.router;
+    let { activeTransition } = routes;
     let headData = get(this, 'headData');
     if (activeTransition) {
       activeTransition.promise.finally(function () {


### PR DESCRIPTION
ember-router.router renamed to ember-router._routerMicrolib in ember 2.13
https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib