### PR TITLE
Add blank object fallback for routes in integration tests

### DIFF
--- a/addon/helpers/page-title.js
+++ b/addon/helpers/page-title.js
@@ -33,7 +33,7 @@ export default Ember.Helper.extend({
 
     let router = getOwner(this).lookup('router:main');
     let routes = router._routerMicrolib || router.router;
-    let { activeTransition } = routes;
+    let { activeTransition } = routes || {};
     let headData = get(this, 'headData');
     if (activeTransition) {
       activeTransition.promise.finally(function () {


### PR DESCRIPTION
Closes #75 

We again had the same issue as the one in #48.

This provides a fallback if both properties are undefined, allowing activeTransitions to end up being `undefined` instead of failing by trying to deconstruct an `undefined`