### PR TITLE
Update to ember-cli-head 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-head": "^0.3.1",
+    "ember-cli-head": "^0.4.0",
     "ember-cli-babel": "^6.7.1"
   },
   "devDependencies": {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,4 @@
+{{head-layout}}
 {{#unless (equals currentRouteName 'index')}}
   {{title "My App"}}
 {{/unless}}


### PR DESCRIPTION
Fixes #104 

Might need to add [a note like `ember-cli-head`](https://github.com/ronco/ember-cli-head#version) does concerning supported Ember and FastBoot versions: "Take into account that version >= 0.3 of this addon require Ember 2.10+ and fastboot >=1.0.rc1 Please use 0.2.X if you don't fulfull both requirements."