### PR TITLE
Set prepend by default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This file is added automatically if you use `ember install`. This is for all the
 
 | attribute | type    | default |
 |-----------|:--------|:--------|
-| separator | string  | `" \| "` |
-| prepend   | boolean | false   |
+| separator | string  | `" \| "`|
+| prepend   | boolean | true    |
 | replace   | boolean | false   |
 
 These defaults are configurable in `config/environment.js`:

--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -29,9 +29,9 @@ export default Service.extend({
     The default prepend value to use.
 
     @property defaultPrepend
-    @default null
+    @default true
    */
-  defaultPrepend: null,
+  defaultPrepend: true,
 
   /**
     The default replace value to use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-page-title",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -16,7 +16,7 @@ module('Acceptance: title', function(hooks) {
     assert.expect(1);
     await visit('/posts');
 
-    assert.equal(title(), 'My App | Posts');
+    assert.equal(title(), 'Posts | My App');
   });
 
   test('the replace attribute works', async function (assert) {
@@ -30,28 +30,28 @@ module('Acceptance: title', function(hooks) {
     assert.expect(1);
     await visit('/about/authors');
 
-    assert.equal(title(), 'About My App > Authors');
+    assert.equal(title(), 'Authors > About My App');
   });
 
   test('custom separators are inherited', async function (assert) {
     assert.expect(1);
     await visit('/about/authors/profile');
 
-    assert.equal(title(), 'About My App > Authors > Profile');
+    assert.equal(title(), 'Profile > Authors > About My App');
   });
 
   test('multiple components in a row work', async function (assert) {
     assert.expect(1);
     await visit('/posts/rails-is-omakase');
 
-    assert.equal(title(), 'My App | Posts | Rails is Omakase');
+    assert.equal(title(), 'Rails is Omakase | Posts | My App');
   });
 
-  test('the prepend declaration works', async function (assert) {
+  test('the prepend=false declaration works', async function (assert) {
     assert.expect(1);
     await visit('/authors/tomster');
 
-    assert.equal(title(), 'My App | Tomster < Authors');
+    assert.equal(title(), 'My App | Authors < Tomster');
   });
 
   test('replace nested in prepends work', async function (assert) {

--- a/tests/dummy/app/templates/author.hbs
+++ b/tests/dummy/app/templates/author.hbs
@@ -1,2 +1,2 @@
-{{title "Authors" prepend=true separator=' < '}}
+{{title "Authors" prepend=false separator=' < '}}
 {{title model.name}}

--- a/tests/unit/services/page-title-list-test.js
+++ b/tests/unit/services/page-title-list-test.js
@@ -133,8 +133,8 @@ module('service:page-title-list', function(hooks) {
 
     let tokens = list.get('sortedTokens');
     assert.equal(tokens.length, 2);
-    assert.equal(tokens[0].id, 2);
-    assert.equal(tokens[1].id, 3);
+    assert.equal(tokens[0].id, 3);
+    assert.equal(tokens[1].id, 2);
   });
 
   test('removing a token with replace: true will set all previous tokens to be visible', function (assert) {
@@ -150,8 +150,8 @@ module('service:page-title-list', function(hooks) {
 
     let tokens = list.get('sortedTokens');
     assert.equal(tokens.length, 2);
-    assert.equal(tokens[0].id, 1);
-    assert.equal(tokens[1].id, 3);
+    assert.equal(tokens[0].id, 3);
+    assert.equal(tokens[1].id, 1);
   });
 
   test('removing a token with replace: true will only set previous tokens up to the last replace: true to visible', function (assert) {
@@ -180,6 +180,6 @@ module('service:page-title-list', function(hooks) {
     list.push(second);
     list.push(third);
 
-    assert.equal(list.toString(), '1 | 3');
+    assert.equal(list.toString(), '3 | 1');
   });
 });


### PR DESCRIPTION
Fix for #131 

A few tests are still failing. I've left TODO comments in code so we can comment on it easily. 

There are too many options how to sort/prepend and separate tokens and I'm not sure what's the expected output in those cases with crazy combinations.